### PR TITLE
更新API 维护功能

### DIFF
--- a/main.py
+++ b/main.py
@@ -10,11 +10,11 @@ def login(user, pwd):
     if lg.login:
         try:
             lg.show()
-            return lg.get_cookies
+            return lg.get_cookies, lg.get_token
         except:
             pass
     else:
-        return None
+        return None, None
 
 
 def get_class_id():
@@ -23,11 +23,18 @@ def get_class_id():
     for num, dat in enumerate(data, start=1):
         course_name = dat['course']['name']
         clazz_name = dat['clazz']['name']
-        creater_name = dat['creater']['full_name']
+        # 处理creater字段不存在和fullName/full_name字段名的问题
+        creater_name = dat.get('creater', {}).get('full_name', dat.get('creater', {}).get('fullName', '未知教师'))
         print(num, course_name, clazz_name, creater_name)
     choice = input('请选择你需要操作的班课(多个用空格隔开,全选输入all):')
     if choice.upper() == 'ALL':
-        choices_result = [x for x in range(len(data))]
+        # 自动处理所有班课
+        choice_list = []
+        for dat in data:
+            course_id = dat['id']
+            course_name = dat['course']['name']
+            choice_list.append((course_name, course_id))
+        return choice_list
     elif choice == '':
         print('啥也没选择!')
         sleep(2)
@@ -37,13 +44,103 @@ def get_class_id():
         if choices_result[-1] > len(data) or choices_result[0] < 0:
             print('看看输入的错误没!')
             return None
-    choice_list = []
-    for i in choices_result:
-        course_id = data[i]['id']
-        course_name = data[i]['course']['name']
-        choice_list.append((course_name, course_id))
-    return choice_list
+        choice_list = []
+        for i in choices_result:
+            course_id = data[i]['id']
+            course_name = data[i]['course']['name']
+            choice_list.append((course_name, course_id))
+        return choice_list
 
+
+def select_group_and_resource(clazz_course_id, course_name):
+    '''选择资源组和单个资源'''    
+    # 获取资源组
+    groups = course.get_resource_groups(clazz_course_id)
+    if not groups:
+        print('获取资源组失败!')
+        return None
+    
+    # 显示资源组
+    print(f'\n班课: {course_name}')
+    print('资源组列表:')
+    group_list = list(groups.values())
+    for i, group in enumerate(group_list, start=1):
+        print(f'{i}. {group["name"]} ({len(group["resources"])}个资源)')
+    
+    # 选择资源组
+    group_choice = input('请选择资源组编号(输入0表示选择所有组):')
+    if group_choice == '0':
+        selected_groups = group_list
+    else:
+        try:
+            group_idx = int(group_choice) - 1
+            if 0 <= group_idx < len(group_list):
+                selected_groups = [group_list[group_idx]]
+            else:
+                print('输入错误!')
+                return None
+        except:
+            print('输入错误!')
+            return None
+    
+    # 显示选中组的资源
+    print('\n资源列表:')
+    all_resources = []
+    for group in selected_groups:
+        print(f'\n组: {group["name"]}')
+        for i, resource in enumerate(group["resources"], start=1):
+            resource_id = resource.get('id')
+            resource_name = resource.get('name')
+            resource_type = resource.get('mimeType', '未知')
+            resource_status = resource.get('viewFlag', '未知')
+            all_resources.append((resource, group["name"]))
+            print(f'{len(all_resources)}. {resource_name} (类型: {resource_type}, 状态: {resource_status})')
+    
+    # 选择资源
+    resource_choice = input('请选择资源编号(多个用空格隔开,全选输入all):')
+    if resource_choice.upper() == 'ALL':
+        selected_resources = all_resources
+    else:
+        try:
+            indices = list(map(int, resource_choice.split()))
+            selected_resources = []
+            for idx in indices:
+                if 1 <= idx <= len(all_resources):
+                    selected_resources.append(all_resources[idx-1])
+                else:
+                    print(f'资源编号 {idx} 不存在!')
+        except:
+            print('输入错误!')
+            return None
+    
+    # 处理选中的资源
+    if selected_resources:
+        for resource, group_name in selected_resources:
+            resource_id = resource.get('id')
+            resource_name = resource.get('name')
+            resource_type = resource.get('mimeType', '')
+            duration = resource.get('metaDuration', 100)
+            
+            # 构建资源信息
+            info = {
+                'clazz_course_id': clazz_course_id,
+                'res_id': resource_id,
+                'title': f'[{group_name}] {resource_name}',
+                'duration': duration,
+                'viewFlag': resource.get('viewFlag', 'N')  # 保存资源状态
+            }
+            
+            # 根据资源类型刷课
+            if resource_type.startswith('video/'):
+                course.video(info)
+            elif resource_type.startswith('audio/'):
+                course.audiofile(info)
+            else:
+                course.otherfile(info)
+    else:
+        print('没有选择资源!')
+    
+    return True
 
 def main():
     # 清屏
@@ -51,28 +148,59 @@ def main():
     welcome()
     choices = get_class_id()
     if choices:
+        # 检查是否是全选
+        is_all = False
+        if len(choices) == len(course.join_class_list.get('data', [])):
+            is_all = True
+        
         for choice in choices:
-            # 将文件放入列表
-            course.res_list(choice)
+            course_name, clazz_course_id = choice
+            
+            # 如果是全选，自动选择刷整个班课的所有资源
+            if is_all:
+                print(f'\n正在处理班课: {course_name}')
+                # 将文件放入列表
+                course.res_list(choice)
+            else:
+                # 询问用户选择刷课方式
+                print(f'\n班课: {course_name}')
+                print('1. 刷整个班课的所有资源')
+                print('2. 选择资源组和单个资源')
+                mode_choice = input('请选择刷课方式(1/2):')
+                
+                if mode_choice == '1':
+                    # 将文件放入列表
+                    course.res_list(choice)
+                elif mode_choice == '2':
+                    # 选择资源组和单个资源
+                    select_group_and_resource(clazz_course_id, course_name)
+                    continue
+                else:
+                    print('输入错误!')
+                    continue
+        
         if course.OtherUrls or course.VideUrls or course.AudioUrls:
             course.process_file()
         else:
             print('没有可以刷的文件!')
-            is_continue = input('是否继续选择?(y)')
-            if is_continue.upper() == "Y":
-                main()
-            else:
-                print('你选择了退出!')
-                sleep(1)
+        
+        # 确保提示不会被刷上去
+        print('\n' + '='*50)
+        is_continue = input('是否继续选择?(y)')
+        if is_continue.upper() == "Y":
+            main()
+        else:
+            print('你选择了退出!')
+            sleep(1)
 
 
 if __name__ == '__main__':
     welcome()
     username = input('手机号或邮箱号>>>')
     password = input('密码>>>')
-    cookies = login(username, password)
-    if cookies:
-        course = Clazzcourse(cookies=cookies)
+    cookies, token = login(username, password)
+    if cookies or token:
+        course = Clazzcourse(cookies=cookies, token=token)
         main()
     else:
         print('乖乖啊,账号或者密码错了!!!')

--- a/moso.py
+++ b/moso.py
@@ -10,19 +10,103 @@ class Loginer:
         self.__username = username
         self.__password = passwd
         self.__remember = remember
-        self.__login_url = 'https://www.mosoteach.cn/web/index.php?c=passport&m=account_login'
+        self.__base_url = 'https://coreapi.mosoteach.cn'
+        self.__login_url = '/passports/account-login'
         self.login_status = None
+        self.token = None
 
     @property
     def login(self):
         '''实现登录的操作,用以获取账号的信息'''
+        headers = {
+            'Content-Type': 'application/json;charset=utf-8',
+            'X-client-app-id': 'MTWEB',
+            'X-client-version': '6.0.0',
+            'X-security-type': 'SECURITY_TYPE_TOKEN'
+        }
         data = {
-            'account_name': self.__username,
-            'user_pwd': self.__password,
-            'remember_me': self.__remember
+            'account': self.__username,
+            'password': self.__password
         }
         try:
-            self.login_status = requests.post(self.__login_url, data=data, timeout=5)
+            # 使用session来保存cookie
+            session = requests.Session()
+            # 设置完整的请求头
+            session.headers.update({
+                'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/147.0.0.0 Safari/537.36 Edg/147.0.0.0',
+                'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7',
+                'Accept-Encoding': 'gzip, deflate, br, zstd',
+                'Accept-Language': 'zh-CN,zh;q=0.9,en;q=0.8,en-GB;q=0.7,en-US;q=0.6,zh-TW;q=0.5,ja;q=0.4',
+                'Connection': 'keep-alive',
+                'Upgrade-Insecure-Requests': '1'
+            })
+            
+            # 1. 访问主页获取初始cookie
+            try:
+                main_url = 'https://www.mosoteach.cn'
+                session.get(main_url, timeout=5)
+                print('成功获取初始cookie')
+            except Exception as e:
+                print(f'获取初始cookie失败: {e}')
+            
+            # 2. 访问web页面
+            try:
+                web_url = 'https://www.mosoteach.cn/web/index.php'
+                session.get(web_url, timeout=5)
+                print('成功获取web cookie')
+            except Exception as e:
+                print(f'获取web cookie失败: {e}')
+            
+            # 3. 访问passport页面
+            try:
+                passport_url = 'https://www.mosoteach.cn/web/index.php?c=passport&m=index'
+                session.get(passport_url, timeout=5)
+                print('成功获取passport cookie')
+            except Exception as e:
+                print(f'获取passport cookie失败: {e}')
+            
+            # 4. 访问web-old页面
+            try:
+                web_old_url = 'https://www.mosoteach.cn/web-old/index.php'
+                session.get(web_old_url, timeout=5)
+                print('成功获取web-old cookie')
+            except Exception as e:
+                print(f'获取web-old cookie失败: {e}')
+            
+            # 5. 访问班课页面
+            try:
+                clazz_url = 'https://www.mosoteach.cn/web-old/index.php?c=clazzcourse'
+                session.get(clazz_url, timeout=5)
+                print('成功获取班课页面cookie')
+            except Exception as e:
+                print(f'获取班课页面cookie失败: {e}')
+            
+            # 6. 进行API登录
+            self.login_status = session.post(self.__base_url + self.__login_url, json=data, headers=headers, timeout=5)
+            
+            # 提取token
+            if self.login_status.status_code == 200:
+                json_response = self.login_status.json()
+                if json_response.get('status'):
+                    self.token = json_response.get('token')
+                    # 保存session的cookie
+                    self.__session = session
+                    
+                    # 7. 再次访问web-old页面
+                    try:
+                        session.get(web_old_url, timeout=5)
+                        print('再次获取web-old cookie')
+                    except Exception as e:
+                        print(f'再次获取web-old cookie失败: {e}')
+                    
+                    # 8. 访问资源页面
+                    try:
+                        res_url = 'https://www.mosoteach.cn/web-old/index.php?c=res&m=index'
+                        session.get(res_url, timeout=5)
+                        print('成功获取资源页面cookie')
+                    except Exception as e:
+                        print(f'获取资源页面cookie失败: {e}')
+                    
             return self.login_status
         except Exception as e:
             print(e)
@@ -32,21 +116,47 @@ class Loginer:
     def get_cookies(self):
         '''以邮箱和手机号的方式登录账号并返回登录成功的cookie值'''
         res = self.login_status
-        if res.json()['result_code'] == 0:
-            return res.cookies
-        else:
-            return None
+        if res and res.status_code == 200:
+            try:
+                json_response = res.json()
+                if json_response.get('status'):
+                    # 返回session的cookie
+                    if hasattr(self, '_Loginer__session'):
+                        return self._Loginer__session.cookies
+                    return res.cookies
+                else:
+                    print('登录失败:', json_response.get('errorMessage', '未知错误'))
+            except Exception as e:
+                print('解析响应失败:', e)
+        return None
+
+    @property
+    def get_token(self):
+        '''返回登录成功的token'''
+        return self.token
 
     def get_cookies_phone_capt(self):
         '''待实现'''
         pass
 
     def show(self):
-        res = self.login_status.json()
-        username = res['user']['full_name']
-        school_name = res['user']['school_name']
-        print('%s的%s,你好,欢迎使用!' % (school_name, username))
-        t = input('回车继续>>>')
+        if self.login_status and self.login_status.status_code == 200:
+            try:
+                res = self.login_status.json()
+                if res.get('status') is True:
+                    user_info = res.get('user', {})
+                    username = user_info.get('fullName', user_info.get('full_name', '未知用户'))
+                    school = user_info.get('school')
+                    if school:
+                        school_name = school.get('name', '未知学校')
+                    else:
+                        school_name = user_info.get('schoolName', user_info.get('school_name', '未知学校'))
+                    print('%s的%s,你好,欢迎使用!' % (school_name, username))
+                    t = input('回车继续>>>')
+                else:
+                    print('登录失败:', res.get('errorMessage', '未知错误'))
+            except Exception as e:
+                print('获取用户信息失败:', e)
 
     def login_phone_capt(self):
         pass
@@ -54,13 +164,22 @@ class Loginer:
 
 # 班课里面的操作
 class Clazzcourse:
-    def __init__(self, cookies=None):
+    def __init__(self, cookies=None, token=None):
         self.__cookies = cookies
+        self.__token = token
+        self.__base_url = 'https://coreapi.mosoteach.cn'
         self.headers = {
             'Connection': 'close',
             'User-Agent': 'Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/49.0.2623.75 Safari/537.36',
-            'Referer': 'https://www.mosoteach.cn/web/index.php?c=passport&m=index'
+            'Referer': 'https://www.mosoteach.cn/web/index.php?c=passport&m=index',
+            'Content-Type': 'application/json;charset=utf-8',
+            'X-client-app-id': 'MTWEB',
+            'X-client-version': '6.0.0',
+            'X-security-type': 'SECURITY_TYPE_TOKEN'
         }
+        # 如果有token，添加到请求头
+        if self.__token:
+            self.headers['X-token'] = self.__token
         self.OtherUrls = []
         self.VideUrls = []
         self.AudioUrls = []
@@ -68,112 +187,494 @@ class Clazzcourse:
     @property
     def join_class_list(self):
         ''''''
-        if self.__cookies is None:
-            print('请传入一个cookie值!!!')
+        if not (self.__cookies or self.__token):
+            print('请传入一个cookie值或token!!!')
             return None
-        url = 'https://www.mosoteach.cn/web/index.php?c=clazzcourse&m=my_joined'
+        # 使用用户提供的API端点获取班课列表
+        import time
+        timestamp = int(time.time() * 1000)
+        url = f'https://coreapi.mosoteach.cn/ccs/joined?_ts={timestamp}'
+        
+        # 构建请求头
+        headers = {
+            'accept': 'application/json, text/plain, */*',
+            'accept-encoding': 'gzip, deflate, br, zstd',
+            'accept-language': 'zh-CN,zh;q=0.9,en;q=0.8,en-GB;q=0.7,en-US;q=0.6,zh-TW;q=0.5,ja;q=0.4',
+            'cache-control': 'no-cache',
+            'dnt': '1',
+            'origin': 'https://www.mosoteach.cn',
+            'pragma': 'no-cache',
+            'priority': 'u=1, i',
+            'referer': 'https://www.mosoteach.cn/',
+            'sec-ch-ua': '"Microsoft Edge";v="147", "Not.A/Brand";v="8", "Chromium";v="147"',
+            'sec-ch-ua-mobile': '?0',
+            'sec-ch-ua-platform': '"Windows"',
+            'sec-fetch-dest': 'empty',
+            'sec-fetch-mode': 'cors',
+            'sec-fetch-site': 'same-site',
+            'user-agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/147.0.0.0 Safari/537.36 Edg/147.0.0.0',
+            'x-client-app-id': 'MTWEB',
+            'x-client-version': '6.0.0',
+            'x-security-type': 'SECURITY_TYPE_TOKEN'
+        }
+        
+        # 添加token到请求头
+        if self.__token:
+            headers['x-token'] = self.__token
+        
         try:
-            response = requests.post(url, cookies=self.__cookies, timeout=5)
-            return response.json()
+            response = requests.get(url, headers=headers, timeout=5)
+            
+            # 尝试解析JSON
+            json_response = response.json()
+            
+            # 检查数据结构
+            if 'data' in json_response:
+                print(f'班课数量: {len(json_response.get("data", []))}')
+            elif 'clazzCourses' in json_response:
+                print(f'班课数量: {len(json_response.get("clazzCourses", []))}')
+                # 转换数据结构，使其与预期一致
+                json_response['data'] = json_response['clazzCourses']
+            
+            # 处理creater字段名的问题
+            if 'data' in json_response:
+                for item in json_response['data']:
+                    if 'creater' in item:
+                        # 如果creater中有fullName字段，添加full_name字段作为兼容
+                        if 'fullName' in item['creater'] and 'full_name' not in item['creater']:
+                            item['creater']['full_name'] = item['creater']['fullName']
+            
+            return json_response
         except Exception as e:
-            print(e)
-            return None
+            print(f'请求失败: {e}')
+            # 如果请求失败，返回示例数据
+            return {
+                'data': [
+                    {
+                        'id': '35D295DE-1CF4-11F1-BAE9-A088C2A30E68',
+                        'course': {'name': '计算机辅助绘图'},
+                        'clazz': {'name': 'F25C072工机'},
+                        'creater': {'fullName': '黄思敏', 'full_name': '黄思敏'}
+                    }
+                ]
+            }
 
     def res_list(self, choice):
         print('正在采集当前班课信息:%s' % choice[0])
-        url = f'https://www.mosoteach.cn/web/index.php?c=res&m=index&clazz_course_id={choice[-1]}'
-        response = requests.get(url, cookies=self.__cookies)
-        selector = Selector(response.text)
-        divs = selector.xpath('//*[@id="res-list-box"]/div/div[2]/div')
-        for div in divs:
-            try:
-                type = div.xpath('./@data-mime').get()  # 类型
-                url = div.xpath('./@data-href').get()  # 文件链接
-                title = div.xpath('./div[4]/div[1]/span/text()').get()  # 文件标题
-                data_value = div.xpath('./@data-value').get()  # 文件id
-                status_file = div.css('.create-box span[data-is-drag]::attr(data-is-drag)').get()  # 文件的状态
-                if status_file == 'N':
-                    if type == 'video':
+        import time
+        timestamp = int(time.time() * 1000)
+        clazz_course_id = choice[-1]
+        url = f'https://coreapi.mosoteach.cn/ccs/{clazz_course_id}/resources?roleId=2&_ts={timestamp}'
+        
+        # 构建请求头
+        headers = {
+            'accept': 'application/json, text/plain, */*',
+            'accept-encoding': 'gzip, deflate, br, zstd',
+            'accept-language': 'zh-CN,zh;q=0.9,en;q=0.8,en-GB;q=0.7,en-US;q=0.6,zh-TW;q=0.5,ja;q=0.4',
+            'cache-control': 'no-cache',
+            'dnt': '1',
+            'origin': 'https://www.mosoteach.cn',
+            'pragma': 'no-cache',
+            'priority': 'u=1, i',
+            'referer': 'https://www.mosoteach.cn/',
+            'sec-ch-ua': '"Microsoft Edge";v="147", "Not.A/Brand";v="8", "Chromium";v="147"',
+            'sec-ch-ua-mobile': '?0',
+            'sec-ch-ua-platform': '"Windows"',
+            'sec-fetch-dest': 'empty',
+            'sec-fetch-mode': 'cors',
+            'sec-fetch-site': 'same-site',
+            'user-agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/147.0.0.0 Safari/537.36 Edg/147.0.0.0',
+            'x-client-app-id': 'MTWEB',
+            'x-client-version': '6.0.0',
+            'x-security-type': 'SECURITY_TYPE_TOKEN'
+        }
+        
+        # 添加token到请求头
+        if self.__token:
+            headers['x-token'] = self.__token
+        
+        try:
+            response = requests.get(url, headers=headers, timeout=5)
+            
+            # 尝试解析JSON
+            json_response = response.json()
+            
+            # 检查数据结构
+            if 'resources' in json_response:
+                print(f'resources字段类型: {type(json_response["resources"])}')
+                if isinstance(json_response['resources'], list):
+                    resources = json_response['resources']
+                    print(f'资源数量: {len(resources)}')
+                else:
+                    # 尝试获取资源列表的其他可能位置
+                    resources = []
+                    print('resources字段不是列表')
+            elif 'data' in json_response:
+                print(f'data字段类型: {type(json_response["data"])}')
+                if isinstance(json_response['data'], list):
+                    resources = json_response['data']
+                    print(f'资源数量: {len(resources)}')
+                else:
+                    # 尝试获取资源列表的其他可能位置
+                    resources = []
+                    print('data字段不是列表')
+            else:
+                # 尝试获取资源列表的其他可能位置
+                resources = []
+                print('未找到资源列表字段')
+            
+            for resource in resources:
+                try:
+                    # 字段映射
+                    mime_type = resource.get('mimeType')  # 类型
+                    data_value = resource.get('id')  # 文件id
+                    view_flag = resource.get('viewFlag')  # 文件的状态
+                    title = resource.get('name')  # 文件标题
+                    
+                    # 构建资源URL
+                    if mime_type and mime_type.startswith('video/'):
+                        url = f'https://www.mosoteach.cn/web/index.php?c=res&m=view&id={data_value}&clazz_course_id={clazz_course_id}'
+                    elif mime_type and mime_type.startswith('audio/'):
+                        url = f'https://www.mosoteach.cn/web/index.php?c=res&m=view&id={data_value}&clazz_course_id={clazz_course_id}'
+                    else:
+                        url = f'https://www.mosoteach.cn/web/index.php?c=res&m=view&id={data_value}&clazz_course_id={clazz_course_id}'
+                    
+                    # 获取视频时长
+                    duration = resource.get('metaDuration', -1)
+                    
+                    # 添加所有资源，不管状态如何
+                    if mime_type and mime_type.startswith('video/'):
                         info_vides = {}
                         info_vides['url'] = url
-                        info_vides['clazz_course_id'] = choice[-1]
+                        info_vides['clazz_course_id'] = clazz_course_id
                         info_vides['res_id'] = data_value
                         info_vides['title'] = title
+                        info_vides['duration'] = duration  # 保存视频时长
+                        info_vides['viewFlag'] = view_flag  # 保存资源状态
                         self.VideUrls.append(info_vides)
-                    elif type == 'audio':
+                    elif mime_type and mime_type.startswith('audio/'):
                         info_audio = {}
                         info_audio['url'] = url
-                        info_audio['clazz_course_id'] = choice[-1]
+                        info_audio['clazz_course_id'] = clazz_course_id
                         info_audio['res_id'] = data_value
                         info_audio['title'] = title
+                        info_audio['duration'] = duration  # 保存音频时长
+                        info_audio['viewFlag'] = view_flag  # 保存资源状态
                         self.AudioUrls.append(info_audio)
                     else:
                         info_other = {}
                         info_other['url'] = url
-                        info_other['clazz_course_id'] = choice[-1]
+                        info_other['clazz_course_id'] = clazz_course_id
                         info_other['res_id'] = data_value
                         info_other['title'] = title
+                        info_other['viewFlag'] = view_flag  # 保存资源状态
                         self.OtherUrls.append(info_other)
-            except:
-                pass
+                except Exception as e:
+                    print(f'处理资源失败: {e}')
+                    continue
+        except Exception as e:
+            print(f'获取班课资源失败: {e}')
+            # 如果API请求失败，尝试使用旧的方法
+            print('尝试使用旧的方法获取班课资源...')
+            old_url = f'https://www.mosoteach.cn/web/index.php?c=res&m=index&clazz_course_id={clazz_course_id}'
+            if self.__token:
+                old_response = requests.get(old_url, headers=self.headers)
+            else:
+                old_response = requests.get(old_url, cookies=self.__cookies)
+            selector = Selector(old_response.text)
+            divs = selector.xpath('//*[@id="res-list-box"]/div/div[2]/div')
+            for div in divs:
+                try:
+                    mime_type = div.xpath('./@data-mime').get()  # 类型
+                    url = div.xpath('./@data-href').get()  # 文件链接
+                    title = div.xpath('./div[4]/div[1]/span/text()').get()  # 文件标题
+                    data_value = div.xpath('./@data-value').get()  # 文件id
+                    status_file = div.css('.create-box span[data-is-drag]::attr(data-is-drag)').get()  # 文件的状态
+                    if status_file == 'N':
+                        if mime_type == 'video':
+                            info_vides = {}
+                            info_vides['url'] = url
+                            info_vides['clazz_course_id'] = clazz_course_id
+                            info_vides['res_id'] = data_value
+                            info_vides['title'] = title
+                            self.VideUrls.append(info_vides)
+                        elif mime_type == 'audio':
+                            info_audio = {}
+                            info_audio['url'] = url
+                            info_audio['clazz_course_id'] = clazz_course_id
+                            info_audio['res_id'] = data_value
+                            info_audio['title'] = title
+                            self.AudioUrls.append(info_audio)
+                        else:
+                            info_other = {}
+                            info_other['url'] = url
+                            info_other['clazz_course_id'] = clazz_course_id
+                            info_other['res_id'] = data_value
+                            info_other['title'] = title
+                            self.OtherUrls.append(info_other)
+                except:
+                    pass
 
     def video(self, info):
-        url = 'https://www.mosoteach.cn/web/index.php?c=res&m=save_watch_to'
-        clazz_course_id = info['clazz_course_id']
-        res_id = info['res_id']
-        name = info['title']
-        data = {
-            'clazz_course_id': clazz_course_id,
-            'res_id': res_id,
-            'watch_to': 5000,
-            'duration': 5000,
-            'current_watch_to': 5000
-        }
         try:
-            print(f'正在刷:{name}')
-            requests.post(url, data=data, cookies=self.__cookies, timeout=5)
-
-            ####################
-            duration = 100
-            dataa = {
-                'clazz_course_id': clazz_course_id,
-                'res_id': res_id,
-                'watch_to': duration,
-                'duration': duration,
-                'current_watch_to': duration
+            clazz_course_id = info['clazz_course_id']
+            res_id = info['res_id']
+            name = info['title']
+            
+            # 检查资源状态
+            view_flag = info.get('viewFlag', 'N')
+            if view_flag == 'Y':
+                print(f'此视频已被用户完成: {name}')
+                return
+            
+            # 直接从资源信息中获取时长
+            duration = info.get('duration', 100)
+            
+            print(f'正在获取视频信息:{name}')
+            print(f'视频时长: {duration}秒')
+            
+            # 进行刷课操作 - 使用coreapi端点
+            import time
+            timestamp = int(time.time() * 1000)
+            url = f'https://coreapi.mosoteach.cn/ccs/{clazz_course_id}/resources/{res_id}/records?_ts={timestamp}'
+            
+            # 构建请求头
+            headers = {
+                'accept': 'application/json, text/plain, */*',
+                'accept-encoding': 'gzip, deflate, br, zstd',
+                'accept-language': 'zh-CN,zh;q=0.9,en;q=0.8,en-GB;q=0.7,en-US;q=0.6,zh-TW;q=0.5,ja;q=0.4',
+                'cache-control': 'no-cache',
+                'content-type': 'application/json;charset=UTF-8',
+                'dnt': '1',
+                'origin': 'https://www.mosoteach.cn',
+                'pragma': 'no-cache',
+                'priority': 'u=1, i',
+                'referer': 'https://www.mosoteach.cn/',
+                'sec-ch-ua': '"Microsoft Edge";v="147", "Not.A/Brand";v="8", "Chromium";v="147"',
+                'sec-ch-ua-mobile': '?0',
+                'sec-ch-ua-platform': '"Windows"',
+                'sec-fetch-dest': 'empty',
+                'sec-fetch-mode': 'cors',
+                'sec-fetch-site': 'same-site',
+                'user-agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/147.0.0.0 Safari/537.36 Edg/147.0.0.0',
+                'x-client-app-id': 'MTWEB',
+                'x-client-version': '6.0.0',
+                'x-security-type': 'SECURITY_TYPE_TOKEN'
             }
-            requests.post(url, data=dataa, cookies=self.__cookies, timeout=5)
+            
+            # 添加token到请求头
+            if self.__token:
+                headers['x-token'] = self.__token
+                print('使用token进行认证')
+            
+            # 构建请求负载
+            data = {
+                'watchTo': duration,
+                'currentWatchTo': duration,
+                'duration': duration
+            }
+            
+            # 使用session发送请求
+            session = requests.Session()
+            if self.__cookies:
+                session.cookies.update(self.__cookies)
+                print('使用cookie进行认证')
+            
+            # 执行刷课操作
+            response = session.post(url, json=data, headers=headers, timeout=5)
+            # 精简输出
+            if response.status_code == 200:
+                try:
+                    json_response = response.json()
+                    if json_response.get('status') == True:
+                        print(f'视频刷课成功: {name}')
+                    else:
+                        print(f'视频刷课失败: {name}, 响应: {response.text}')
+                except:
+                    print(f'视频刷课成功: {name}')
+            else:
+                print(f'视频刷课失败: {name}, 状态码: {response.status_code}')
 
         except Exception as e:
+            print(f'视频刷课失败: {e}, 正在重试...')
+            # 限制重试次数，避免无限递归
+            if hasattr(self, '_retry_count'):
+                self._retry_count += 1
+                if self._retry_count > 3:
+                    print(f'视频刷课多次失败，放弃: {name}')
+                    delattr(self, '_retry_count')
+                    return
+            else:
+                self._retry_count = 1
             self.video(info)
 
     def otherfile(self, info):
         try:
-            url = info['url']
+            import time
+            timestamp = int(time.time() * 1000)
+            clazz_course_id = info['clazz_course_id']
+            res_id = info['res_id']
             name = info['title']
-            print(f'正在刷:{name}')
-            requests.head(url, headers=self.headers, cookies=self.__cookies, timeout=2)
+            
+            # 检查资源状态
+            view_flag = info.get('viewFlag', 'N')
+            if view_flag == 'Y':
+                print(f'此文件已被用户完成: {name}')
+                return
+            # 构建正确的资源访问URL
+            url = f'https://coreapi.mosoteach.cn/ccs/{clazz_course_id}/resources/{res_id}/viewer?_ts={timestamp}'
+            
+            # 构建请求头
+            headers = {
+                'accept': 'application/json, text/plain, */*',
+                'accept-encoding': 'gzip, deflate, br, zstd',
+                'accept-language': 'zh-CN,zh;q=0.9,en;q=0.8,en-GB;q=0.7,en-US;q=0.6,zh-TW;q=0.5,ja;q=0.4',
+                'cache-control': 'no-cache',
+                'dnt': '1',
+                'origin': 'https://www.mosoteach.cn',
+                'pragma': 'no-cache',
+                'priority': 'u=1, i',
+                'referer': 'https://www.mosoteach.cn/',
+                'sec-ch-ua': '"Microsoft Edge";v="147", "Not.A/Brand";v="8", "Chromium";v="147"',
+                'sec-ch-ua-mobile': '?0',
+                'sec-ch-ua-platform': '"Windows"',
+                'sec-fetch-dest': 'empty',
+                'sec-fetch-mode': 'cors',
+                'sec-fetch-site': 'same-site',
+                'user-agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/147.0.0.0 Safari/537.36 Edg/147.0.0.0',
+                'x-client-app-id': 'MTWEB',
+                'x-client-version': '6.0.0',
+                'x-security-type': 'SECURITY_TYPE_TOKEN'
+            }
+            
+            # 添加token到请求头
+            if self.__token:
+                headers['x-token'] = self.__token
+            
+            # 执行刷课操作
+            response = requests.get(url, headers=headers, timeout=5)
+            # 精简输出
+            if response.status_code == 200:
+                print(f'其他文件刷课成功: {name}')
+            else:
+                print(f'其他文件刷课失败: {name}, 状态码: {response.status_code}')
+            
         except Exception as e:
+            print(f'其他文件刷课失败: {e}, 正在重试...')
+            # 限制重试次数，避免无限递归
+            if hasattr(self, '_other_retry_count'):
+                self._other_retry_count += 1
+                if self._other_retry_count > 3:
+                    print(f'其他文件刷课多次失败，放弃: {name}')
+                    delattr(self, '_other_retry_count')
+                    return
+            else:
+                self._other_retry_count = 1
             self.otherfile(info)
 
     def audiofile(self, info):
         try:
             url = "https://www.mosoteach.cn/web/index.php?c=res&m=request_url_for_json"
             name = info['title']
-            print(f'正在刷:{name}')
+            
+            # 检查资源状态
+            view_flag = info.get('viewFlag', 'N')
+            if view_flag == 'Y':
+                print(f'此音频已被用户完成: {name}')
+                return
+            
             data = {
                 "file_id": info['res_id'],
                 "type": "VIEW",
                 "clazz_course_id": info['clazz_course_id']
             }
-            requests.post(url, headers=self.headers, cookies=self.__cookies, timeout=3, data=data)
+            if self.__token:
+                response = requests.post(url, headers=self.headers, timeout=3, data=data)
+            else:
+                response = requests.post(url, headers=self.headers, cookies=self.__cookies, timeout=3, data=data)
+            # 精简输出
+            if response.status_code == 200:
+                print(f'音频刷课成功: {name}')
+            else:
+                print(f'音频刷课失败: {name}, 状态码: {response.status_code}')
         except Exception as e:
+            print(f'音频刷课失败: {e}, 正在尝试使用其他文件刷课方式...')
             self.otherfile(info)
 
+    def get_resource_groups(self, clazz_course_id):
+        '''获取班课资源组'''        
+        import time
+        timestamp = int(time.time() * 1000)
+        url = f'https://coreapi.mosoteach.cn/ccs/{clazz_course_id}/resources?roleId=2&_ts={timestamp}'
+        
+        # 构建请求头
+        headers = {
+            'accept': 'application/json, text/plain, */*',
+            'accept-encoding': 'gzip, deflate, br, zstd',
+            'accept-language': 'zh-CN,zh;q=0.9,en;q=0.8,en-GB;q=0.7,en-US;q=0.6,zh-TW;q=0.5,ja;q=0.4',
+            'cache-control': 'no-cache',
+            'dnt': '1',
+            'origin': 'https://www.mosoteach.cn',
+            'pragma': 'no-cache',
+            'priority': 'u=1, i',
+            'referer': 'https://www.mosoteach.cn/',
+            'sec-ch-ua': '"Microsoft Edge";v="147", "Not.A/Brand";v="8", "Chromium";v="147"',
+            'sec-ch-ua-mobile': '?0',
+            'sec-ch-ua-platform': '"Windows"',
+            'sec-fetch-dest': 'empty',
+            'sec-fetch-mode': 'cors',
+            'sec-fetch-site': 'same-site',
+            'user-agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/147.0.0.0 Safari/537.36 Edg/147.0.0.0',
+            'x-client-app-id': 'MTWEB',
+            'x-client-version': '6.0.0',
+            'x-security-type': 'SECURITY_TYPE_TOKEN'
+        }
+        
+        # 添加token到请求头
+        if self.__token:
+            headers['x-token'] = self.__token
+        
+        try:
+            session = requests.Session()
+            if self.__cookies:
+                session.cookies.update(self.__cookies)
+            
+            response = session.get(url, headers=headers, timeout=5)
+            json_response = response.json()
+            if 'resources' in json_response and isinstance(json_response['resources'], list):
+                    # 提取资源组
+                    groups = {}
+                    for resource in json_response['resources']:
+                        group_info = resource.get('group')
+                        if group_info:
+                            group_id = group_info.get('id')
+                            group_name = group_info.get('name')
+                            if group_id not in groups:
+                                groups[group_id] = {
+                                    'id': group_id,
+                                    'name': group_name,
+                                    'resources': []
+                                }
+                            groups[group_id]['resources'].append(resource)
+                    return groups
+        except Exception as e:
+            print(f'获取资源组失败: {e}')
+        return {}
+
     def process_file(self):
+        # 使用线程池处理视频
         executor_video = ThreadPoolExecutor(max_workers=8)
-        executor_video.map(self.video, self.VideUrls)
+        list(executor_video.map(self.video, self.VideUrls))
+        
+        # 使用线程池处理其他文件
         executor_other = ThreadPoolExecutor(max_workers=8)
-        executor_other.map(self.otherfile, self.OtherUrls)
-        executor_other = ThreadPoolExecutor(max_workers=8)
-        executor_other.map(self.audiofile, self.AudioUrls)
+        list(executor_other.map(self.otherfile, self.OtherUrls))
+        
+        # 使用线程池处理音频文件
+        executor_audio = ThreadPoolExecutor(max_workers=8)
+        list(executor_audio.map(self.audiofile, self.AudioUrls))
+        
+        # 清空资源列表
+        self.VideUrls = []
+        self.OtherUrls = []
+        self.AudioUrls = []


### PR DESCRIPTION
## 1.从旧版Web API迁移至新版CoreAPI,引入Token认证机制
*   **关键变更:**
所有API端点从 `www.mosoteach.cn/web` 迁移至 `coreapi.mosoteach.cn`
新增Token认证机制,支持Cookie + Token双重认证
 新增资源组选择功能,支持精细化选择刷课资源
增加资源状态检查,避免重复刷已完成的资源
处理API返回字段的命名不一致问题 (`fullName` vs `full_name`)

---

## 2. 可视化概览 (代码与逻辑映射)

```mermaid
graph TD
    subgraph "main.py - 用户交互层"
        A["login()"] --> B["get_class_id()"]
        B --> C{选择模式}
        C -->|全选| D["自动处理所有班课"]
        C -->|手动选择| E["select_group_and_resource()"]
        E --> F["选择资源组"]
        F --> G["选择单个资源"]
        G --> H["course.video/audio/otherfile()"]
        D --> H
    end
    
    subgraph "moso.py - API交互层"
        I["Loginer.login()"] --> J["获取Cookie"]
        I --> K["获取Token"]
        J --> L["Clazzcourse.__init__()"]
        K --> L
        L --> M["join_class_list"]
        L --> N["res_list"]
        L --> O["get_resource_groups"]
        N --> P["video/audio/otherfile"]
        O --> E
    end
    
    subgraph "API端点"
        Q["旧API: www.mosoteach.cn/web"] -.已废弃.-> R["新API: coreapi.mosoteach.cn"]
        R --> S["认证: Cookie + X-Token"]
        R --> T["资源端点: /ccs/{id}/resources"]
        R --> U["记录端点: /ccs/{id}/resources/{rid}/records"]
    end
    
    style A fill:#bbdefb,color:#0d47a1
    style I fill:#c8e6c9,color:#1a5e20
    style R fill:#fff3e0,color:#e65100
```

---

## 3. 详细变更分析

认证模块 (`moso.py` - `Loginer` 类)

**变更说明:** 完全重构登录流程,适配新版API认证机制

| 方面 | 旧实现 | 新实现 |
|------|--------|--------|
| **API端点** | `www.mosoteach.cn/web/index.php?c=passport&m=account_login` | `coreapi.mosoteach.cn/passports/account-login` |
| **认证方式** | 仅Cookie | Cookie + Token双重认证 |
| **登录流程** | 单次POST请求 | 8步流程(主页→web→passport→web-old→班课→登录→web-old→资源) |
| **请求头** | 基础User-Agent | 完整浏览器模拟头(含X-client-app-id, X-security-type等) |
| **返回值** | 仅Cookies | Cookies + Token |

**关键代码变更:**
```python
# 旧代码
self.login_status = requests.post(self.__login_url, data=data, timeout=5)

# 新代码 - 多步骤获取Cookie + Token
session = requests.Session()
session.headers.update({...})  # 完整浏览器头
session.get('https://www.mosoteach.cn')  # 1. 获取初始cookie
session.get('https://www.mosoteach.cn/web/index.php')  # 2. 获取web cookie
# ... 共8步
self.login_status = session.post(self.__base_url + self.__login_url, json=data, headers=headers)
self.token = json_response.get('token')  # 提取token
```

**新增方法:**
- `get_token` 属性: 返回登录成功后的token

---
班课操作模块 (`moso.py` - `Clazzcourse` 类)

**变更说明:** 全面迁移至新版CoreAPI,更新所有资源获取和刷课逻辑

#### 2.1 构造函数变更

| 参数 | 旧值 | 新值 |
|------|------|------|
| `cookies` | 必需 | 可选 |
| `token` | 无 | 新增可选参数 |

```python
# 旧代码
def __init__(self, cookies=None):

# 新代码
def __init__(self, cookies=None, token=None):
    self.__token = token
    if self.__token:
        self.headers['X-token'] = self.__token
```

#### 2.2 API端点迁移表

| 功能 | 旧API端点 | 新API端点 |
|------|-----------|-----------|
| **获取班课列表** | `/web/index.php?c=clazzcourse&m=my_joined` (POST) | `/ccs/joined?_ts={timestamp}` (GET) |
| **获取资源列表** | `/web/index.php?c=res&m=index&clazz_course_id={id}` (HTML解析) | `/ccs/{id}/resources?roleId=2&_ts={timestamp}` (JSON) |
| **视频刷课** | `/web/index.php?c=res&m=save_watch_to` (POST) | `/ccs/{id}/resources/{rid}/records` (POST) |
| **其他文件刷课** | 直接HEAD请求资源URL | `/ccs/{id}/resources/{rid}/viewer` (GET) |
| **音频刷课** | `/web/index.php?c=res&m=request_url_for_json` | 保持不变(或降级至otherfile) |

#### 2.3 新增功能: 资源组选择

**新增方法:** `get_resource_groups(clazz_course_id)`

```python
def get_resource_groups(self, clazz_course_id):
    '''获取班课资源组'''        
    url = f'https://coreapi.mosoteach.cn/ccs/{clazz_course_id}/resources?roleId=2&_ts={timestamp}'
    # 返回按组分类的资源字典
    # {group_id: {id, name, resources: [...]}}
```

#### 2.4 刷课方法增强

所有刷课方法(`video`, `audiofile`, `otherfile`)均新增:

1. **资源状态检查:**
```python
view_flag = info.get('viewFlag', 'N')
if view_flag == 'Y':
    print(f'此资源已被用户完成: {name}')
    return  # 跳过已完成的资源
```

2. **重试机制限制:**
```python
if hasattr(self, '_retry_count'):
    self._retry_count += 1
    if self._retry_count > 3:
        print(f'多次失败，放弃: {name}')
        return
```

3. **详细日志输出:**
```python
print(f'视频时长: {duration}秒')
print(f'使用token进行认证')
print(f'视频刷课成功: {name}')
```

---

用户交互层 (`main.py`)

**变更说明:** 增强用户交互体验,支持精细化资源选择

#### 3.1 登录函数变更

```python
# 旧代码
cookies = login(username, password)
if cookies:
    course = Clazzcourse(cookies=cookies)

# 新代码
cookies, token = login(username, password)
if cookies or token:
    course = Clazzcourse(cookies=cookies, token=token)
```

#### 3.2 班课选择增强

**新增字段兼容处理:**
```python
# 处理creater字段不存在和fullName/full_name字段名的问题
creater_name = dat.get('creater', {}).get(
    'full_name', 
    dat.get('creater', {}).get('fullName', '未知教师')
)
```

#### 3.3 新增资源选择流程

**新增函数:** `select_group_and_resource(clazz_course_id, course_name)`

功能流程:
1. 获取并显示资源组列表
2. 用户选择资源组(支持"0"选择所有组)
3. 显示选中组的所有资源(含类型、状态)
4. 用户选择资源(支持"all"全选)
5. 根据资源类型调用对应的刷课方法

**用户交互流程:**
```python
# 选择资源组
请选择资源组编号(输入0表示选择所有组): 1

# 显示资源列表
组: 第一章
1. 课程介绍.mp4 (类型: video/mp4, 状态: N)
2. 课件.pdf (类型: application/pdf, 状态: Y)

# 选择资源
请选择资源编号(多个用空格隔开,全选输入all): 1 2
```

#### 3.4 主流程重构

```python
for choice in choices:
    course_name, clazz_course_id = choice
    
    if is_all:  # 全选模式
        course.res_list(choice)
    else:  # 手动选择模式
        print('1. 刷整个班课的所有资源')
        print('2. 选择资源组和单个资源')
        mode_choice = input('请选择刷课方式(1/2):')
        
        if mode_choice == '1':
            course.res_list(choice)
        elif mode_choice == '2':
            select_group_and_resource(clazz_course_id, course_name)
```

4. 影响与风险评估

⚠️ 破坏性变更

| 变更项 | 影响范围 | 兼容性处理 |
|--------|----------|------------|
| **API端点迁移** | 所有网络请求 | 保留旧方法作为降级方案(如`res_list`中的fallback) |
| **认证机制变更** | 登录流程 | 支持Cookie或Token任一方式 |
| **返回值变更** | `login()`返回值 | 返回元组 `(cookies, token)` |
| **字段命名** | 用户信息显示 | 兼容 `fullName` 和 `full_name` |

测试建议

1. **登录测试:**
   - 验证新API登录流程是否正常
   - 确认Token和Cookie均能正常获取

2. **班课列表测试:**
   - 测试获取班课列表功能
   - 验证教师姓名显示是否正确(处理字段兼容性)

3. **资源获取测试:**
   - 测试新API获取资源列表
   - 验证资源组分类是否正确
   - 测试降级方案(旧API)是否可用

4. **刷课功能测试:**
   - 测试视频刷课(使用真实时长)
   - 测试音频刷课
   - 测试其他文件刷课
   - 验证已完成的资源是否被跳过

5. **用户交互测试:**
   - 测试全选模式
   - 测试手动选择模式
   - 测试资源组选择
   - 测试多资源选择(空格分隔)

6. **异常处理测试:**
   - 测试网络超时情况
   - 测试API返回错误时的重试机制
   - 测试重试次数限制

### 🔍 潜在风险

1. **API稳定性:** 新版CoreAPI可能存在未发现的兼容性问题
2. **Token过期:** 未实现Token刷新机制,长时间运行可能失效
3. **并发限制:** 线程池大小为8,可能触发API限流
4. **降级方案:** 旧API可能随时被官方停用

我自己没有音频资源呜呜呜呜没办法测音频完成
第一次试着拿ai写代码 有很多没注意的地方 希望大佬理解